### PR TITLE
revamped envsampler

### DIFF
--- a/src/Tools/envsampler.jl
+++ b/src/Tools/envsampler.jl
@@ -3,7 +3,11 @@ struct TrajectoryBuffer{B1<:ElasticBuffer,B2<:ElasticBuffer}
     terminal::B2
 end
 
-function TrajectoryBuffer(env::AbstractEnvironment; sizehint::Maybe{Integer} = nothing, dtype::Maybe{DataType} = nothing)
+function TrajectoryBuffer(
+    env::AbstractEnvironment;
+    sizehint::Maybe{Integer} = nothing,
+    dtype::Maybe{DataType} = nothing,
+)
     sp = dtype === nothing ? spaces(env) : adapt(dtype, spaces(env))
 
     trajectory = ElasticBuffer(
@@ -11,7 +15,7 @@ function TrajectoryBuffer(env::AbstractEnvironment; sizehint::Maybe{Integer} = n
         observations = sp.obsspace,
         actions = sp.actionspace,
         rewards = sp.rewardspace,
-        evaluations = sp.evalspace
+        evaluations = sp.evalspace,
     )
 
     terminal = ElasticBuffer(
@@ -21,7 +25,7 @@ function TrajectoryBuffer(env::AbstractEnvironment; sizehint::Maybe{Integer} = n
         lengths = Int,
     )
 
-    if !isnothing(sizehint)
+    if sizehint !== nothing
         sizehint!(trajectory, sizehint)
         sizehint!(terminal, sizehint)
     end
@@ -36,18 +40,19 @@ struct EnvSampler{E<:AbstractEnvironment,B<:TrajectoryBuffer,BA}
     batch::BA
 end
 
-function EnvSampler(env_tconstructor::Function; sizehint::Union{Integer,Nothing} = nothing, dtype::Maybe{DataType} = nothing)
+function EnvSampler(
+    env_tconstructor::Function;
+    sizehint::Maybe{Integer} = nothing,
+    dtype::Maybe{DataType} = nothing,
+)
     envs = [e for e in env_tconstructor(Threads.nthreads())]
-    bufs = [TrajectoryBuffer(first(envs), sizehint=sizehint, dtype=dtype) for _ = 1:Threads.nthreads()]
-    batch = makebatch(first(envs), sizehint=sizehint, dtype=dtype)
-    EnvSampler(envs, bufs, batch)
-end
+    bufs = [
+        TrajectoryBuffer(first(envs), sizehint = sizehint, dtype = dtype)
+        for _ = 1:Threads.nthreads()
+    ]
+    batch = _makebatch(first(envs), sizehint = sizehint, dtype = dtype)
 
-function emptybufs!(sampler::EnvSampler)
-    for buf in sampler.bufs
-        empty!(buf.trajectory)
-        empty!(buf.terminal)
-    end
+    EnvSampler(envs, bufs, batch)
 end
 
 
@@ -68,7 +73,7 @@ function sample!(
 
     atomiccount = Threads.Atomic{Int}(0)
     atomicidx = Threads.Atomic{Int}(1)
-    emptybufs!(sampler)
+    _emptybufs!(sampler)
 
     if nthreads == 1
         _sample!(actionfn!, resetfn!, sampler, nsamples, Hmax)
@@ -85,12 +90,10 @@ function sample!(
         end
     end
 
-    @assert sum(b -> length(b.trajectory), sampler.bufs) >= nsamples
-
-    collate!(sampler, nsamples, copy)
+    _collate!(sampler, nsamples, copy)
+    _checkbatch(sampler.batch, nsamples)
     sampler.batch
 end
-
 
 function _sample!(actionfn!::F, resetfn!::G, sampler, nsamples, Hmax) where {F,G}
     env = first(sampler.envs)
@@ -101,11 +104,11 @@ function _sample!(actionfn!::F, resetfn!::G, sampler, nsamples, Hmax) where {F,G
     resetfn!(env)
     trajlength = n = 0
     while n < nsamples
-        done = rolloutstep!(actionfn!, traj, env)
+        done = _rolloutstep!(actionfn!, traj, env)
         trajlength += 1
 
         if done || trajlength == Hmax
-            terminate!(term, env, trajlength, done)
+            _terminate_trajectory!(term, env, trajlength, done)
             resetfn!(env)
             n += trajlength
             trajlength = 0
@@ -113,7 +116,6 @@ function _sample!(actionfn!::F, resetfn!::G, sampler, nsamples, Hmax) where {F,G
     end
     nothing
 end
-
 
 function _threadsample!(
     actionfn!::F,
@@ -131,13 +133,13 @@ function _threadsample!(
     resetfn!(env)
     trajlength = 0
     while true
-        done = rolloutstep!(actionfn!, traj, env)
+        done = _rolloutstep!(actionfn!, traj, env)
         trajlength += 1
 
         if done || trajlength == Hmax
             Threads.atomic_add!(atomiccount, trajlength)
-            terminate!(term, env, trajlength, done)
-            if atomiccount[] > nsamples
+            _terminate_trajectory!(term, env, trajlength, done)
+            if atomiccount[] >= nsamples
                 break
             else
                 resetfn!(env)
@@ -148,32 +150,34 @@ function _threadsample!(
     nothing
 end
 
-
-function rolloutstep!(actionfn!::F, traj::ElasticBuffer, env::AbstractEnvironment) where {F}
+function _rolloutstep!(actionfn!::F, traj::ElasticBuffer, env::AbstractEnvironment) where {F}
     grow!(traj)
     t = lastindex(traj)
     @uviews traj begin
-        st, ot, at =
-            view(traj.states, :, t), view(traj.observations, :, t), view(traj.actions, :, t)
+        st = view(traj.states, :, t)
+        ot = view(traj.observations, :, t)
+        at = view(traj.actions, :, t)
 
         getstate!(st, env)
         getobs!(ot, env)
-        actionfn!(at, st, ot)
 
+        actionfn!(at, st, ot)
         setaction!(env, at)
+
         step!(env)
 
-        r = getreward(st, at, ot, env)
-        e = geteval(st, at, ot, env)
-        done = isdone(st, at, ot, env)
-
-        traj.rewards[t] = r
-        traj.evaluations[t] = e
-        return done
+        traj.rewards[t] = getreward(st, at, ot, env)
+        traj.evaluations[t] = geteval(st, at, ot, env)
+        return isdone(st, at, ot, env)
     end
 end
 
-function terminate!(term::ElasticBuffer, env::AbstractEnvironment, trajlength::Integer, done::Bool)
+function _terminate_trajectory!(
+    term::ElasticBuffer,
+    env::AbstractEnvironment,
+    trajlength::Integer,
+    done::Bool,
+)
     grow!(term)
     i = lastindex(term)
     @uviews term begin
@@ -186,9 +190,21 @@ function terminate!(term::ElasticBuffer, env::AbstractEnvironment, trajlength::I
     term
 end
 
+function _emptybufs!(sampler::EnvSampler)
+    for buf in sampler.bufs
+        empty!(buf.trajectory)
+        empty!(buf.terminal)
+    end
+    nothing
+end
 
-function makebatch(env::AbstractEnvironment; sizehint::Union{Integer,Nothing} = nothing, dtype::Maybe{DataType} = nothing)
+function _makebatch(
+    env::AbstractEnvironment;
+    sizehint::Maybe{Integer} = nothing,
+    dtype::Maybe{DataType} = nothing,
+)
     sp = dtype === nothing ? spaces(env) : adapt(dtype, spaces(env))
+
     batch = (
         states = BatchedArray(sp.statespace),
         observations = BatchedArray(sp.obsspace),
@@ -199,34 +215,37 @@ function makebatch(env::AbstractEnvironment; sizehint::Union{Integer,Nothing} = 
         terminal_observations = BatchedArray(sp.obsspace),
         dones = Vector{Bool}(),
     )
+
     sizehint !== nothing && foreach(el -> sizehint!(el, sizehint), batch)
+
     batch
 end
 
-function collate!(sampler::EnvSampler, N::Integer, copy::Bool)
+function _collate!(sampler::EnvSampler, N::Integer, copy::Bool)
     batch = copy ? map(deepcopy, sampler.batch) : sampler.batch # TODO
     for b in batch
         empty!(b)
         sizehint!(b, N)
     end
 
-    @info sum(sampler.bufs) do buf
-        sum(buf.terminal.lengths)
-    end
-
     count = 0
     togo = N - count
     for buf in sampler.bufs
-
         trajbuf = buf.trajectory
         termbuf = buf.terminal
         from = firstindex(trajbuf)
 
         @uviews trajbuf termbuf for episode_idx in eachindex(termbuf)
             togo = N - count
-            togo == 0 && break
+            togo == 0 && return batch
 
-            len = min(togo, termbuf.lengths[episode_idx])
+            len = termbuf.lengths[episode_idx]
+            if togo < len # we only want `N` samples
+                len = togo
+                # because we cropped this trajectory, it didn't actually terminate early
+                termbuf.dones[episode_idx] = false
+            end
+
             until = from + len
             to = until - 1
             count += len
@@ -245,24 +264,16 @@ function collate!(sampler::EnvSampler, N::Integer, copy::Bool)
 
             from = until
         end
-        togo == 0 && break
     end
-
-    nbatches = length(batch.dones)
-    @assert length(batch.terminal_states) ==
-            length(batch.terminal_observations) ==
-            length(batch.dones)
-    @assert nsamples(batch.states) == N
-    @assert nsamples(batch.observations) == N
-    @assert nsamples(batch.actions) == N
-    @assert nsamples(batch.rewards) == N
-    @assert nsamples(batch.evaluations) == N
-
     batch
 end
 
-function _defaultnthreads(nsamples, Hmax, nthreads)
-    d, r = divrem(nsamples, Hmax)
-    r > 0 && (d += 1)
-    min(d, nthreads)
+function _checkbatch(b, n)
+    @assert n == nsamples(b.states)
+    @assert n == nsamples(b.observations)
+    @assert n == nsamples(b.actions)
+    @assert n == nsamples(b.rewards)
+    @assert n == nsamples(b.evaluations)
+    @assert length(b.dones) == length(b.terminal_states) == length(b.terminal_observations)
+    nothing
 end

--- a/src/Tools/envsampler.jl
+++ b/src/Tools/envsampler.jl
@@ -76,6 +76,7 @@ function sample!(
     _emptybufs!(sampler)
 
     if nthreads == 1
+        # short circuit
         _sample!(actionfn!, resetfn!, sampler, nsamples, Hmax)
     else
         @sync for _ = 1:nthreads
@@ -108,9 +109,9 @@ function _sample!(actionfn!::F, resetfn!::G, sampler, nsamples, Hmax) where {F,G
         trajlength += 1
 
         if done || trajlength == Hmax
+            n += trajlength
             _terminate_trajectory!(term, env, trajlength, done)
             resetfn!(env)
-            n += trajlength
             trajlength = 0
         end
     end


### PR DESCRIPTION
1. Fixes issue discovered by @klowrey where previous `EnvSampler` would bias towards trajectories that required less CPU time.
2. Properly handles "done" in the case that we cropped the last trajectory.

supersedes #13 